### PR TITLE
Sharpen time picker highlight

### DIFF
--- a/style.css
+++ b/style.css
@@ -240,14 +240,29 @@ h1,h2,h3 { margin: 0; }
 
 /* Wheel */
 .wheel{ position: relative; display:grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px;
-  padding: 12px 8px; border: 1px solid var(--line); border-radius: 14px; background: var(--chs-teal-050); overflow: hidden; }
-.picker-mask{ position:absolute; left: 8px; right: 8px; top: 50%; height: 36px; transform: translateY(-50%); border-radius: 10px;
-  box-shadow: 0 0 0 1px rgba(0,0,0,.06) inset; pointer-events:none; }
-.picker-col{ position: relative; height: 180px; overflow-y: auto; overscroll-behavior: contain; scroll-snap-type: y mandatory; padding-block: 72px;
-  scrollbar-width: none; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
+  padding: 12px 8px; border: 1px solid var(--line); border-radius: 14px; background: #f7fbfb; overflow: hidden; }
+.picker-mask{ position:absolute; inset: 0; pointer-events:none; }
+.picker-mask::before{ content:""; position:absolute; inset:0;
+  background: linear-gradient(180deg, rgba(247,251,251,1) 0%, rgba(247,251,251,.85) 26%, rgba(247,251,251,0) 40%, rgba(247,251,251,0) 60%, rgba(247,251,251,.85) 74%, rgba(247,251,251,1) 100%);
+}
+.picker-mask::after{ content:""; position:absolute; left: 6px; right: 6px; top: 50%; height: 36px;
+  transform: translateY(-50%); border-radius: 12px; background: rgba(255,255,255,.35);
+  border: 1px solid rgba(58,125,124,.28); box-shadow: 0 6px 18px rgba(12,44,44,.12);
+}
+.picker-col{ position: relative; height: 180px; overflow-y: auto; overscroll-behavior: contain;
+  scrollbar-width: none; -webkit-overflow-scrolling: touch; touch-action: pan-y; scroll-snap-type: y mandatory;
+  scroll-snap-stop: always; scroll-padding-block: 50%; outline: none; }
 .picker-col::-webkit-scrollbar{ display:none; }
-.picker-item{ height: 36px; display:flex; align-items:center; justify-content:center; font-weight: 700; color: var(--ink); scroll-snap-align: center; scroll-snap-stop: always; }
+.picker-col:focus-visible{ box-shadow: 0 0 0 2px rgba(58,125,124,.25) inset; border-radius: 12px; }
+.picker-item{ height: 36px; display:flex; align-items:center; justify-content:center; font-weight: 700; color: var(--muted);
+  transition: color .18s ease, text-shadow .18s ease; scroll-snap-align: center; font-variant-numeric: tabular-nums;
+  backface-visibility: hidden; position: relative; }
+.picker-item.selected{ color: var(--ink); font-weight: 800; letter-spacing: .01em; text-shadow: 0 0 0 rgba(0,0,0,0); }
 .pm-col{ display:flex; align-items:center; justify-content:center; }
+
+@media (prefers-reduced-motion: reduce){
+  .picker-item{ transition: none; }
+}
 
 /* Spa picker layout */
 .spa-grid{


### PR DESCRIPTION
## Summary
- soften the picker mask gradients and tighten the highlight window to match the row height for a crisper viewport
- remove the selected-row scale transform and boost typography weight to keep the active value sharp while still emphasized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d972f9193c8330be86eb096dcedc2a