### PR TITLE
Refine time selector styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -172,8 +172,14 @@ h1,h2,h3 { margin: 0; }
 
 /* Timefield (expected arr/dep) */
 .timefield{
-  border:1px solid var(--line); border-radius:10px; padding:8px 10px; min-width:140px;
-  cursor:pointer; background:#fff;
+  border:1px solid var(--line); border-radius:10px; padding:8px 12px; min-width:140px;
+  cursor:pointer; background:#fff; font-variant-numeric: tabular-nums;
+  font-weight:600; color:var(--ink); box-shadow:0 3px 10px rgba(11,13,16,.04);
+  transition:border-color .2s ease, box-shadow .2s ease;
+}
+.timefield:focus-visible{
+  outline:none; border-color:var(--chs-teal);
+  box-shadow:0 0 0 3px rgba(58,125,124,.18), 0 6px 16px rgba(11,13,16,.08);
 }
 
 /* ===== Check-in / out editor ===== */
@@ -185,9 +191,14 @@ h1,h2,h3 { margin: 0; }
 .io-fields{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
 .io-fields.expected label{ display:flex; gap:6px; align-items:center; }
 .io-time, .io-note{
-  border:1px solid var(--line); border-radius:10px; padding:8px 10px; font:inherit; min-width: 180px;
+  border:1px solid var(--line); border-radius:10px; padding:9px 12px; font:inherit; min-width: 180px;
+  transition:border-color .2s ease, box-shadow .2s ease; background:#fff;
 }
-.io-time{ width: 120px; }
+.io-time{ width: 120px; font-weight:600; font-variant-numeric: tabular-nums; text-align:center; }
+.io-time:focus-visible, .io-note:focus-visible{
+  outline:none; border-color:var(--chs-teal);
+  box-shadow:0 0 0 3px rgba(58,125,124,.16);
+}
 .io-note{ flex: 1 1 260px; }
 .io-static{ color:var(--muted); }
 .muted.small{ font-size:12px }
@@ -239,19 +250,28 @@ h1,h2,h3 { margin: 0; }
 .picker-hint{ color: var(--muted); font-size: 12px; margin-top: 8px; }
 
 /* Wheel */
-.wheel{ position: relative; display:grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px;
-  padding: 12px 8px; border: 1px solid var(--line); border-radius: 14px; background: var(--chs-teal-050); overflow: hidden; }
-.picker-mask{ position:absolute; left: 8px; right: 8px; top: 50%; height: 36px; transform: translateY(-50%); border-radius: 10px;
-  box-shadow: 0 0 0 1px rgba(0,0,0,.06) inset; pointer-events:none; background: rgba(255,255,255,.55); backdrop-filter: blur(6px); }
-.picker-col{ position: relative; height: 180px; overflow-y: auto; overscroll-behavior: contain;
+.wheel{ position: relative; display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px;
+  padding: 14px 10px; border: 1px solid rgba(58,125,124,.25); border-radius: 16px; background: linear-gradient(180deg, #f5faf9 0%, #ffffff 55%, #f5faf9 100%); box-shadow: 0 20px 35px rgba(58,125,124,.12), 0 2px 8px rgba(11,13,16,.05); overflow: hidden; }
+.picker-mask{ position:absolute; inset:4px 10px; pointer-events:none; border-radius:12px; z-index:0;
+  background: linear-gradient(180deg, rgba(245,250,249,.88)0%, rgba(245,250,249,0)32%, rgba(245,250,249,0)68%, rgba(245,250,249,.88)100%);
+}
+.picker-mask::after{ content:""; position:absolute; left:10px; right:10px; top:50%; height:40px; transform:translateY(-50%);
+  border-radius:12px; background: rgba(255,255,255,.96);
+  box-shadow:0 0 0 1px rgba(58,125,124,.35) inset, 0 8px 16px rgba(58,125,124,.12); }
+.picker-col{ position: relative; height: 180px; overflow-y: auto; overscroll-behavior: contain; z-index:1;
   scrollbar-width: none; -webkit-overflow-scrolling: touch; touch-action: pan-y; scroll-snap-type: y proximity;
-  scroll-padding-block: 50%; outline: none; }
+  scroll-padding-block: 50%; outline: none; padding-inline:2px; }
 .picker-col::-webkit-scrollbar{ display:none; }
 .picker-col:focus-visible{ box-shadow: 0 0 0 2px rgba(58,125,124,.25) inset; border-radius: 12px; }
-.picker-item{ height: 36px; display:flex; align-items:center; justify-content:center; font-weight: 700; color: var(--muted);
+.picker-item{ height: 40px; display:flex; align-items:center; justify-content:center; font-weight: 600; color: var(--muted);
+  font-size:16px; letter-spacing:.01em;
   transition: transform .18s ease, color .18s ease, text-shadow .18s ease; scroll-snap-align: center; font-variant-numeric: tabular-nums; }
-.picker-item.selected{ color: var(--ink); transform: scale(1.08); text-shadow: 0 0 1px rgba(11,13,16,.25); }
-.pm-col{ display:flex; align-items:center; justify-content:center; }
+.picker-item.selected{ color: var(--ink); transform: scale(1.1); text-shadow: 0 4px 12px rgba(11,13,16,.18); }
+.pm-col{ display:flex; align-items:center; justify-content:center; font-weight:700; color:var(--chs-teal); position:relative; z-index:1;
+  background: rgba(255,255,255,.9); border-radius:12px; box-shadow: inset 0 0 0 1px rgba(58,125,124,.25); font-size:15px;
+  min-height: 180px; padding:0 6px;
+}
+.pm-col .picker-item{ color:inherit; font-weight:700; letter-spacing:.06em; }
 
 @media (prefers-reduced-motion: reduce){
   .picker-item{ transition: none; }


### PR DESCRIPTION
## Summary
- restyle the expected arrival/departure time fields for stronger contrast and focus feedback
- refresh the time selection wheels with clearer typography, highlight band, and consistent layout
- polish the dinner PM column so it matches the new picker finish

## Testing
- Manual testing by loading index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68d98cab325083309ec0d0100ac918e3