### PR TITLE
Ensure dinner covers everyone and simplify guest tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -219,6 +219,7 @@ h1,h2,h3 { margin: 0; }
 .tag{ background:#eef2f3; border:1px solid var(--line); padding:3px 8px; border-radius:999px; font-size:12px }
 .tag.loc{ background:#f1f1f1 }
 .tag.guest{ background:#e8efe9; border-color:#d8e4de; color:#223b2b; font-weight:600 }
+.tag.everyone{ background:#e5ecff; border-color:#ccd9ff; color:#23315c; font-weight:600 }
 .pill.inline{ margin-left: auto; }
 
 /* ===== Preview Pane ===== */


### PR DESCRIPTION
## Summary
- ensure dinner reservations always include every guest and prevent per-guest dinner tags in the preview
- collapse activity chips to a single "Everyone" pill when all guests participate and add styling for the new tag
- merge overlapping blocks before raising the lunch window warning and refresh the day list after adding a guest

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d9c2b3bd408330b4ec342b106e68df